### PR TITLE
2 bugs fixed

### DIFF
--- a/Mina.NET/Core/Session/AbstractIoSessionConfig.cs
+++ b/Mina.NET/Core/Session/AbstractIoSessionConfig.cs
@@ -115,6 +115,7 @@ namespace Mina.Core.Session
             if (config == null)
                 throw new ArgumentNullException("config");
             ReadBufferSize = config.ReadBufferSize;
+            WriteTimeout = config.WriteTimeout;
             SetIdleTime(IdleStatus.BothIdle, config.GetIdleTime(IdleStatus.BothIdle));
             SetIdleTime(IdleStatus.ReaderIdle, config.GetIdleTime(IdleStatus.ReaderIdle));
             SetIdleTime(IdleStatus.WriterIdle, config.GetIdleTime(IdleStatus.WriterIdle));

--- a/Mina.NET/Transport/Socket/AsyncDatagramConnector.cs
+++ b/Mina.NET/Transport/Socket/AsyncDatagramConnector.cs
@@ -65,9 +65,16 @@ namespace Mina.Transport.Socket
             writeBuffer.SetBuffer(new Byte[SessionConfig.ReadBufferSize], 0, SessionConfig.ReadBufferSize);
             writeBuffer.Completed += new EventHandler<SocketAsyncEventArgs>(SocketAsyncEventArgs_Completed);
 
-            EndConnect(new AsyncDatagramSession(this, Processor, connector.Socket, connector.RemoteEP,
-                new SocketAsyncEventArgsBuffer(readBuffer), new SocketAsyncEventArgsBuffer(writeBuffer),
-                ReuseBuffer), connector);
+            try
+            {
+                EndConnect(new AsyncDatagramSession(this, Processor, connector.Socket, connector.RemoteEP,
+                    new SocketAsyncEventArgsBuffer(readBuffer), new SocketAsyncEventArgsBuffer(writeBuffer),
+                    ReuseBuffer), connector);
+            }
+            catch (Exception ex)
+            {
+                Util.ExceptionMonitor.Instance.ExceptionCaught(ex);
+            }
         }
 
         void SocketAsyncEventArgs_Completed(object sender, SocketAsyncEventArgs e)

--- a/Mina.NET/Transport/Socket/AsyncSocketConnector.cs
+++ b/Mina.NET/Transport/Socket/AsyncSocketConnector.cs
@@ -77,9 +77,16 @@ namespace Mina.Transport.Socket
                 writeBuffer.SetBuffer(new Byte[SessionConfig.ReadBufferSize], 0, SessionConfig.ReadBufferSize);
                 writeBuffer.Completed += new EventHandler<SocketAsyncEventArgs>(SocketAsyncEventArgs_Completed);
 
-                EndConnect(new AsyncSocketSession(this, Processor, connector.Socket,
-                    new SocketAsyncEventArgsBuffer(readBuffer), new SocketAsyncEventArgsBuffer(writeBuffer),
-                    ReuseBuffer), connector);
+                try
+                {
+                    EndConnect(new AsyncSocketSession(this, Processor, connector.Socket,
+                        new SocketAsyncEventArgsBuffer(readBuffer), new SocketAsyncEventArgsBuffer(writeBuffer),
+                        ReuseBuffer), connector);
+                }
+                catch (Exception ex)
+                {
+                    Util.ExceptionMonitor.Instance.ExceptionCaught(ex);
+                }
             }
             else
             {


### PR DESCRIPTION
1.Repair timeout setting is invalid

2.Fixed an issue where uncaught exceptions("System.ObjectDisposedException") could cause the program to crash;
-----====================================================--------
at System.Threading.TimerQueueTimer.Change(UInt32 dueTime, UInt32 period)
   at System.Threading.Timer.Change(Int32 dueTime, Int32 period)
   at Mina.Transport.Socket.AbstractSocketConnector.EndConnect(IoSession session, ConnectorContext connector)
   at Mina.Transport.Socket.AsyncSocketConnector.ProcessConnect(SocketAsyncEventArgs e)
   at Mina.Transport.Socket.AsyncSocketConnector.SocketAsyncEventArgs_Completed(Object sender, SocketAsyncEventArgs e)
   at System.Net.Sockets.SocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs e)
   at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationSuccess(SocketError socketError, Int32 bytesTransferred, SocketFlags flags)
   at System.Net.Sockets.SocketAsyncEventArgs.CompletionPortCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP)
-----====================================================--------